### PR TITLE
Add cron API test and update mocks

### DIFF
--- a/tests/api/cron.test.ts
+++ b/tests/api/cron.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test, jest, beforeEach, afterEach } from '@jest/globals';
+import { prisma } from '@/lib/prisma';
+import { checkDKIM, checkSPF, checkDMARC } from '@/utils/dns';
+
+const originalSecret = process.env.CRON_SECRET;
+
+describe('Cron Check Domains API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.CRON_SECRET = originalSecret;
+  });
+
+  test('returns 200 when secret is correct', async () => {
+    process.env.CRON_SECRET = 'secret';
+
+    const { GET } = await import('@/app/api/cron/check-domains/route');
+
+    const mockDomains = [
+      { id: '1', name: 'example.com', dkimSelector: 'selector' },
+    ];
+    (prisma.domain.findMany as jest.Mock).mockResolvedValue(mockDomains);
+    (prisma.domain.update as jest.Mock).mockResolvedValue({});
+    (checkDKIM as jest.Mock).mockResolvedValue({ status: 'success', value: 'dkim' });
+    (checkSPF as jest.Mock).mockResolvedValue({ status: 'success', value: 'spf' });
+    (checkDMARC as jest.Mock).mockResolvedValue({ status: 'success', value: 'dmarc' });
+
+    const request = new Request('http://localhost', {
+      headers: { Authorization: 'Bearer secret' }
+    });
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ success: true, message: 'Domains checked successfully' });
+    expect(prisma.domain.findMany).toHaveBeenCalled();
+    expect(prisma.domain.update).toHaveBeenCalled();
+  });
+
+  test('returns 401 when secret is missing', async () => {
+    process.env.CRON_SECRET = 'secret';
+
+    const { GET } = await import('@/app/api/cron/check-domains/route');
+
+    const request = new Request('http://localhost');
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  test('returns 401 when secret is wrong', async () => {
+    process.env.CRON_SECRET = 'secret';
+
+    const { GET } = await import('@/app/api/cron/check-domains/route');
+
+    const request = new Request('http://localhost', {
+      headers: { Authorization: 'Bearer wrong' }
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/tests/api/domains.test.ts
+++ b/tests/api/domains.test.ts
@@ -63,6 +63,7 @@ describe('Domain API Endpoints', () => {
   describe('DELETE /api/domains/[id]', () => {
     test('should delete domain successfully', async () => {
       // Explicitly resolve the delete operation
+      (prisma.domain.findUnique as jest.Mock).mockResolvedValueOnce({ id: '123' });
       (prisma.domain.delete as jest.Mock).mockResolvedValueOnce({});
 
       const request = new NextRequest('http://localhost');
@@ -76,6 +77,7 @@ describe('Domain API Endpoints', () => {
     });
 
     test('should handle deletion error', async () => {
+      (prisma.domain.findUnique as jest.Mock).mockResolvedValueOnce({ id: '123' });
       (prisma.domain.delete as jest.Mock).mockRejectedValue(new Error('Delete failed'));
 
       const request = new NextRequest('http://localhost');

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,27 +1,41 @@
 import { jest } from '@jest/globals';
 import { NextRequest, NextResponse } from 'next/server';
 
-jest.mock('next/server', () => ({
-  NextRequest: function(url: string, init?: RequestInit) {
-    return {
-      url,
-      ...(init || {}),
-      json: () => Promise.resolve(init?.body ? JSON.parse(init.body as string) : {})
-    } as unknown as NextRequest;
-  },
-  NextResponse: {
-    json: (data: any, init?: ResponseInit) => new Response(
-      data === null ? null : JSON.stringify(data),
-      init
-    ),
+jest.mock('next/server', () => {
+  class MockNextResponse extends Response {
+    constructor(body?: BodyInit | null, init?: ResponseInit) {
+      super(body, init);
+    }
+
+    static json(data: any, init?: ResponseInit) {
+      return new MockNextResponse(
+        data === null ? null : JSON.stringify(data),
+        init
+      );
+    }
   }
-}));
+
+  return {
+    NextRequest: function(url: string, init?: RequestInit) {
+      return {
+        url,
+        ...(init || {}),
+        json: () =>
+          Promise.resolve(
+            init?.body ? JSON.parse(init.body as string) : {}
+          )
+      } as unknown as NextRequest;
+    },
+    NextResponse: MockNextResponse
+  };
+});
 
 // Mock Prisma
 jest.mock('@/lib/prisma', () => ({
   prisma: {
     domain: {
       findUnique: jest.fn(),
+      findMany: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
     },
@@ -33,4 +47,9 @@ jest.mock('@/utils/dns', () => ({
   checkDKIM: jest.fn(),
   checkSPF: jest.fn(),
   checkDMARC: jest.fn(),
+}));
+
+// Mock Prisma error class to avoid loading the real @prisma/client ESM module
+jest.mock('@prisma/client', () => ({
+  Prisma: { PrismaClientKnownRequestError: class extends Error {} }
 }));


### PR DESCRIPTION
## Summary
- add cron.check-domains API tests for auth logic
- extend NextResponse mock to support constructor
- mock `findMany` and Prisma error class
- update domain delete tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840120f9c4c8321ba83b586a8688470