### PR TITLE
Validate cron secret in domain check

### DIFF
--- a/src/app/api/cron/check-domains/route.ts
+++ b/src/app/api/cron/check-domains/route.ts
@@ -2,13 +2,14 @@ import { prisma } from '@/lib/prisma';
 import { checkDKIM, checkSPF, checkDMARC } from '@/utils/dns';
 import { NextResponse } from 'next/server';
 
-// Vercel cron jobs are protected by a secret header
+// Vercel cron jobs require the CRON_SECRET environment variable and
+// expect requests to include `Authorization: Bearer <CRON_SECRET>`
 const CRON_SECRET = process.env.CRON_SECRET;
 
 export async function GET(request: Request) {
   // Verify the request is from Vercel Cron
   const authHeader = request.headers.get('Authorization');
-  if (authHeader !== `Bearer ${CRON_SECRET}`) {
+  if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
 


### PR DESCRIPTION
## Summary
- require CRON_SECRET before accepting cron job requests

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm test` *(fails: ESM import issues with Prisma)*

------
https://chatgpt.com/codex/tasks/task_e_68401221218c83218a79477552a85905