### PR TITLE
Add domain check history

### DIFF
--- a/prisma/migrations/20250604094858_add_domain_check/migration.sql
+++ b/prisma/migrations/20250604094858_add_domain_check/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "DomainCheck" (
+    "id" TEXT NOT NULL,
+    "domainId" TEXT NOT NULL,
+    "dkim" TEXT,
+    "spf" TEXT,
+    "dmarc" TEXT,
+    "dkimStatus" TEXT,
+    "spfStatus" TEXT,
+    "dmarcStatus" TEXT,
+    "checkedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "DomainCheck_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "DomainCheck" ADD CONSTRAINT "DomainCheck_domainId_fkey" FOREIGN KEY ("domainId") REFERENCES "Domain"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,4 +40,18 @@ model Domain {
   updatedAt          DateTime @updatedAt
   espId              String?
   esp                Esp?     @relation(fields: [espId], references: [id])
+  checks             DomainCheck[]
+}
+
+model DomainCheck {
+  id          String   @id @default(cuid())
+  domainId    String
+  domain      Domain   @relation(fields: [domainId], references: [id])
+  dkim        String?
+  spf         String?
+  dmarc       String?
+  dkimStatus  String?
+  spfStatus   String?
+  dmarcStatus String?
+  checkedAt   DateTime @default(now())
 }

--- a/src/app/api/cron/check-domains/route.ts
+++ b/src/app/api/cron/check-domains/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: Request) {
         checkDMARC(domain.name),
       ]);
 
-      await prisma.domain.update({
+      const updated = await prisma.domain.update({
         where: { id: domain.id },
         data: {
           dkim: dkimResult.details ? `${dkimResult.value} (${dkimResult.details})` : dkimResult.value,
@@ -33,6 +33,19 @@ export async function GET(request: Request) {
           spfStatus: spfResult.status,
           dmarcStatus: dmarcResult.status,
           lastChecked: new Date(),
+        },
+      });
+
+      await prisma.domainCheck.create({
+        data: {
+          domainId: updated.id,
+          dkim: updated.dkim,
+          spf: updated.spf,
+          dmarc: updated.dmarc,
+          dkimStatus: updated.dkimStatus,
+          spfStatus: updated.spfStatus,
+          dmarcStatus: updated.dmarcStatus,
+          checkedAt: updated.lastChecked,
         },
       });
     }

--- a/src/app/api/domains/[id]/history/route.ts
+++ b/src/app/api/domains/[id]/history/route.ts
@@ -1,0 +1,26 @@
+import { prisma } from '@/lib/prisma';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET(_request: Request, context: { params: { id: string } }) {
+  const { id } = context.params;
+  if (!id) {
+    return NextResponse.json({ error: 'Domain ID is required' }, { status: 400 });
+  }
+
+  const limit = Number(new URL(_request.url).searchParams.get('limit') ?? '10');
+
+  try {
+    const history = await prisma.domainCheck.findMany({
+      where: { domainId: id },
+      orderBy: { checkedAt: 'desc' },
+      take: limit,
+    });
+    return NextResponse.json(history);
+  } catch (error) {
+    console.error('Error fetching history:', error);
+    return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 });
+  }
+}

--- a/src/app/api/domains/[id]/route.ts
+++ b/src/app/api/domains/[id]/route.ts
@@ -52,6 +52,19 @@ export async function GET(
       },
     });
 
+    await prisma.domainCheck.create({
+      data: {
+        domainId: updatedDomain.id,
+        dkim: updatedDomain.dkim,
+        spf: updatedDomain.spf,
+        dmarc: updatedDomain.dmarc,
+        dkimStatus: updatedDomain.dkimStatus,
+        spfStatus: updatedDomain.spfStatus,
+        dmarcStatus: updatedDomain.dmarcStatus,
+        checkedAt: updatedDomain.lastChecked,
+      },
+    });
+
     return NextResponse.json({
       ...updatedDomain,
       lastChecked: updatedDomain.lastChecked.toISOString(),

--- a/src/components/DomainCard.tsx
+++ b/src/components/DomainCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { 
+import {
   ChevronDownIcon, 
   ArrowPathIcon,
   TrashIcon,
@@ -14,6 +14,7 @@ import {
   XCircleIcon,
   PencilIcon
 } from '@heroicons/react/24/outline';
+import DomainHistory from './DomainHistory';
 
 export type DNSStatus = 'success' | 'error' | 'not-configured' | 'advisory';
 
@@ -364,6 +365,7 @@ export default function DomainCard({ domain, onRefresh, onDelete, onEdit }: Doma
                 <h4 className="font-semibold text-midnight-navy mb-3">DMARC Record</h4>
                 {formatRecord(domain.dmarc, domain.dmarcStatus, 'dmarc')}
               </div>
+              <DomainHistory domainId={domain.id} />
             </div>
           </motion.div>
         )}

--- a/src/components/DomainHistory.tsx
+++ b/src/components/DomainHistory.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export type DomainCheckEntry = {
+  id: string;
+  dkim: string | null;
+  spf: string | null;
+  dmarc: string | null;
+  dkimStatus?: string | null;
+  spfStatus?: string | null;
+  dmarcStatus?: string | null;
+  checkedAt: string;
+};
+
+type Props = { domainId: string };
+
+export default function DomainHistory({ domainId }: Props) {
+  const [history, setHistory] = useState<DomainCheckEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/domains/${domainId}/history`);
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || 'Failed to fetch history');
+        setHistory(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch history');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [domainId]);
+
+  if (loading) return <p className="text-sm text-deep-teal">Loading history...</p>;
+  if (error) return <p className="text-sm text-red-600">{error}</p>;
+
+  return (
+    <div className="mt-6">
+      <h4 className="font-semibold text-midnight-navy mb-3">Check History</h4>
+      <table className="w-full text-sm text-left border-collapse">
+        <thead>
+          <tr>
+            <th className="py-2 px-3">Checked</th>
+            <th className="py-2 px-3">DKIM</th>
+            <th className="py-2 px-3">SPF</th>
+            <th className="py-2 px-3">DMARC</th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.map((h) => (
+            <tr key={h.id} className="border-t">
+              <td className="py-2 px-3 whitespace-nowrap">
+                {new Date(h.checkedAt).toLocaleString()}
+              </td>
+              <td className="py-2 px-3">{h.dkimStatus}</td>
+              <td className="py-2 px-3">{h.spfStatus}</td>
+              <td className="py-2 px-3">{h.dmarcStatus}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/scripts/updateDNS.ts
+++ b/src/scripts/updateDNS.ts
@@ -14,13 +14,29 @@ async function updateDomainRecords() {
         checkDMARC(domain.name),
       ]);
 
-      await prisma.domain.update({
+      const updated = await prisma.domain.update({
         where: { id: domain.id },
         data: {
           dkim: dkimResult.details ? `${dkimResult.value} (${dkimResult.details})` : dkimResult.value,
           spf: spfResult.details ? `${spfResult.value} (${spfResult.details})` : spfResult.value,
           dmarc: dmarcResult.details ? `${dmarcResult.value} (${dmarcResult.details})` : dmarcResult.value,
+          dkimStatus: dkimResult.status,
+          spfStatus: spfResult.status,
+          dmarcStatus: dmarcResult.status,
           lastChecked: new Date(),
+        },
+      });
+
+      await prisma.domainCheck.create({
+        data: {
+          domainId: updated.id,
+          dkim: updated.dkim,
+          spf: updated.spf,
+          dmarc: updated.dmarc,
+          dkimStatus: updated.dkimStatus,
+          spfStatus: updated.spfStatus,
+          dmarcStatus: updated.dmarcStatus,
+          checkedAt: updated.lastChecked,
         },
       });
       

--- a/tests/api/cron.test.ts
+++ b/tests/api/cron.test.ts
@@ -22,7 +22,17 @@ describe('Cron Check Domains API', () => {
       { id: '1', name: 'example.com', dkimSelector: 'selector' },
     ];
     (prisma.domain.findMany as jest.Mock).mockResolvedValue(mockDomains);
-    (prisma.domain.update as jest.Mock).mockResolvedValue({});
+    (prisma.domain.update as jest.Mock).mockResolvedValue({
+      id: '1',
+      dkim: 'dkim',
+      spf: 'spf',
+      dmarc: 'dmarc',
+      dkimStatus: 'success',
+      spfStatus: 'success',
+      dmarcStatus: 'success',
+      lastChecked: new Date(),
+    });
+    (prisma.domainCheck.create as jest.Mock).mockResolvedValue({});
     (checkDKIM as jest.Mock).mockResolvedValue({ status: 'success', value: 'dkim' });
     (checkSPF as jest.Mock).mockResolvedValue({ status: 'success', value: 'spf' });
     (checkDMARC as jest.Mock).mockResolvedValue({ status: 'success', value: 'dmarc' });
@@ -37,6 +47,7 @@ describe('Cron Check Domains API', () => {
     expect(data).toEqual({ success: true, message: 'Domains checked successfully' });
     expect(prisma.domain.findMany).toHaveBeenCalled();
     expect(prisma.domain.update).toHaveBeenCalled();
+    expect(prisma.domainCheck.create).toHaveBeenCalled();
   });
 
   test('returns 401 when secret is missing', async () => {

--- a/tests/api/domains.test.ts
+++ b/tests/api/domains.test.ts
@@ -34,6 +34,7 @@ describe('Domain API Endpoints', () => {
         spf: mockDNSResult.value,
         dmarc: mockDNSResult.value,
       });
+      (prisma.domainCheck.create as jest.Mock).mockResolvedValue({});
 
       const request = new NextRequest('http://localhost');
       const response = await GET(request, { params: { id: '123' } });
@@ -46,6 +47,7 @@ describe('Domain API Endpoints', () => {
       expect(prisma.domain.findUnique).toHaveBeenCalledWith({
         where: { id: '123' }
       });
+      expect(prisma.domainCheck.create).toHaveBeenCalled();
     });
 
     test('should return 404 for non-existent domain', async () => {
@@ -125,6 +127,23 @@ describe('Domain API Endpoints', () => {
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data).toHaveProperty('error', 'dismissedAdvisories must be an array');
+    });
+  });
+
+  describe('GET /api/domains/[id]/history', () => {
+    test('should return history entries', async () => {
+      (prisma.domainCheck.findMany as jest.Mock).mockResolvedValue([
+        { id: '1', checkedAt: new Date().toISOString() },
+      ]);
+      const { GET } = await import('@/app/api/domains/[id]/history/route');
+
+      const request = new NextRequest('http://localhost');
+      const response = await GET(request, { params: { id: '123' } });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.length).toBe(1);
+      expect(prisma.domainCheck.findMany).toHaveBeenCalled();
     });
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -39,6 +39,10 @@ jest.mock('@/lib/prisma', () => ({
       update: jest.fn(),
       delete: jest.fn(),
     },
+    domainCheck: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
   },
 }));
 


### PR DESCRIPTION
## Summary
- create `DomainCheck` model and migration
- track checks in cron job and manual routes
- expose `/api/domains/[id]/history`
- show history on the domain card UI
- cover history logic with tests

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684015f2093c8321a60bf3b7347f128c